### PR TITLE
fopen命令を fopen_s命令に変更しました。

### DIFF
--- a/samples/OpenGL/basic/lib/stb_image.c
+++ b/samples/OpenGL/basic/lib/stb_image.c
@@ -286,9 +286,10 @@ static unsigned char *stbi_load_main(stbi *s, int *x, int *y, int *comp, int req
 unsigned char *stbi_load(char const *filename, int *x, int *y, int *comp, int req_comp)
 {
    FILE *f = NULL;
-   fopen_s(&f, filename, "rb");
+   errno_t errno;
+   errno = fopen_s(&f, filename, "rb");
    unsigned char *result;
-   if (!f) return epuc("can't fopen", "Unable to open file");
+   if (errno!=0) return epuc("can't fopen", "Unable to open file");
    result = stbi_load_from_file(f,x,y,comp,req_comp);
    fclose(f);
    return result;
@@ -349,9 +350,10 @@ float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *user, int 
 float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp)
 {
    FILE *f = NULL;
-   fopen_s(&f, filename, "rb");
+   errno_t errno;
+   errno = fopen_s(&f, filename, "rb");
    float *result;
-   if (!f) return epf("can't fopen", "Unable to open file");
+   if (errno!=0) return epf("can't fopen", "Unable to open file");
    result = stbi_loadf_from_file(f,x,y,comp,req_comp);
    fclose(f);
    return result;
@@ -388,9 +390,10 @@ int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len)
 extern int      stbi_is_hdr          (char const *filename)
 {
    FILE *f = NULL;
-   fopen_s(&f, filename, "rb");
+   errno_t errno;
+   errno = fopen_s(&f, filename, "rb");
    int result=0;
-   if (f) {
+   if (errno!=0) {
       result = stbi_is_hdr_from_file(f);
       fclose(f);
    }
@@ -4290,9 +4293,10 @@ static int stbi_info_main(stbi *s, int *x, int *y, int *comp)
 int stbi_info(char const *filename, int *x, int *y, int *comp)
 {
     FILE *f = NULL;
-    fopen_s(&f, filename, "rb");
-    int result;
-    if (!f) return e("can't fopen", "Unable to open file");
+	errno_t errno;
+	errno = fopen_s(&f, filename, "rb");
+	int result;
+    if (errno!=0) return e("can't fopen", "Unable to open file");
     result = stbi_info_from_file(f, x, y, comp);
     fclose(f);
     return result;

--- a/samples/OpenGL/basic/lib/stb_image.c
+++ b/samples/OpenGL/basic/lib/stb_image.c
@@ -285,7 +285,8 @@ static unsigned char *stbi_load_main(stbi *s, int *x, int *y, int *comp, int req
 #ifndef STBI_NO_STDIO
 unsigned char *stbi_load(char const *filename, int *x, int *y, int *comp, int req_comp)
 {
-   FILE *f = fopen(filename, "rb");
+   FILE *f = NULL;
+   fopen_s(&f, filename, "rb");
    unsigned char *result;
    if (!f) return epuc("can't fopen", "Unable to open file");
    result = stbi_load_from_file(f,x,y,comp,req_comp);
@@ -347,7 +348,8 @@ float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *user, int 
 #ifndef STBI_NO_STDIO
 float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp)
 {
-   FILE *f = fopen(filename, "rb");
+   FILE *f = NULL;
+   fopen_s(&f, filename, "rb");
    float *result;
    if (!f) return epf("can't fopen", "Unable to open file");
    result = stbi_loadf_from_file(f,x,y,comp,req_comp);
@@ -385,7 +387,8 @@ int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len)
 #ifndef STBI_NO_STDIO
 extern int      stbi_is_hdr          (char const *filename)
 {
-   FILE *f = fopen(filename, "rb");
+   FILE *f = NULL;
+   fopen_s(&f, filename, "rb");
    int result=0;
    if (f) {
       result = stbi_is_hdr_from_file(f);
@@ -4286,7 +4289,8 @@ static int stbi_info_main(stbi *s, int *x, int *y, int *comp)
 #ifndef STBI_NO_STDIO
 int stbi_info(char const *filename, int *x, int *y, int *comp)
 {
-    FILE *f = fopen(filename, "rb");
+    FILE *f = NULL;
+    fopen_s(&f, filename, "rb");
     int result;
     if (!f) return e("can't fopen", "Unable to open file");
     result = stbi_info_from_file(f, x, y, comp);


### PR DESCRIPTION
VS 2017 を使用して、sampleをビルドするとエラーとして処理されます。
無視する設定を行うことで回避可能ではありますが、できるだけ手間なしに
サンプルを動かしてもらうことを狙いとして修正を行いました。

ご確認、よろしくお願いします。